### PR TITLE
🔴 fix(useValidator): los inputs se comen los espacios al teclear (churn de errors/state en validate)

### DIFF
--- a/src/runtime/composables/useValidator.ts
+++ b/src/runtime/composables/useValidator.ts
@@ -31,15 +31,25 @@ function extractConstraints<T extends object>(constructor: () => void): { [K in 
 }
 
 function applyErrors(result: ValidationError[], errors: Record<string, string>, state: Record<string, boolean | null>) {
-  for (const key of Object.keys(errors)) {
-    errors[key] = '';
-    state[key] = true;
-  }
+  const failures = new Map<string, string>();
 
   for (const error of result) {
     const messages = error.constraints ? Object.values(error.constraints) : [];
-    errors[error.property] = messages[0] || 'Invalid';
-    state[error.property] = false;
+    failures.set(error.property, messages[0] || 'Invalid');
+  }
+
+  const keys = new Set([...Object.keys(errors), ...failures.keys()]);
+
+  for (const key of keys) {
+    const message = failures.get(key) ?? '';
+    const isValid = !failures.has(key);
+
+    // Write only on real changes: resetting and re-applying the same values
+    // marks the attrs computed dirty on every validate(), re-rendering every
+    // bound input mid-typing — BFormInput then re-syncs its DOM value from
+    // the trimmed model and drops the trailing space the user just typed.
+    if (errors[key] !== message) errors[key] = message;
+    if (state[key] !== isValid) state[key] = isValid;
   }
 }
 


### PR DESCRIPTION
## Problema

En el admin, escribir "Loja Centro" en el Nome del modal de armazém o "Distribuidora ABC" en el form de fornecedor produce **"LojaCentro"** / **"DistribuidoraABC"** — la barra espaciadora parece no funcionar (reproducido con keypress individual de espacio en pruebas E2E). En cambio, el form de producto o el de cliente conservan los espacios.

Cadena causal:

1. Los forms validan con `@input="validate()"` en cada pulsación.
2. `applyErrors` **resetea** todos los `errors`/`state` (`''`/`true`) y luego re-aplica los fallos. Ese toggle reset→set marca dirty el computed `attrs` aunque el resultado final sea idéntico.
3. `mergeAttrs` construye objetos nuevos en cada evaluación → todos los inputs con `v-bind="attrs.x"` reciben props nuevas → re-render en pleno tecleo.
4. `BFormInput` re-sincroniza su value del DOM desde el modelo al re-renderizar; con `v-model.trim` el modelo nunca contiene el espacio final que se acaba de teclear → el espacio desaparece del input.

Por eso solo afecta a forms con algún campo **permanentemente inválido** que fuerza el toggle en cada validate — p. ej. el `logo: ""` del vendor que falla `@IsUrl` (ver merkaly-io/api.merkaly.io#1268) o el address del warehouse — mientras que producto/cliente, con todos los campos válidos, no re-renderizan y conservan espacios.

## Solución

`applyErrors` ahora calcula el valor final por campo (mensaje y validez) y **solo asigna cuando difiere** del actual. Sin escrituras redundantes, `attrs` permanece referencialmente estable mientras se teclea y los inputs no se re-renderizan ni pierden el espacio final. El comportamiento observable de la validación (mensajes, estados, `valid`) es idéntico.

Nota: requiere release del paquete y bump de `@merkaly/nuxt` en las apps consumidoras (el admin usa 0.7.2 desde el registry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)