### PR TITLE
🟠 fix(app): los toasts aparecen arriba-centro y tapan el botón primario del header

### DIFF
--- a/src/runtime/components/app.vue
+++ b/src/runtime/components/app.vue
@@ -25,7 +25,7 @@ hook('page:finish', () => regenerate());
 
 <template>
   <main>
-    <Notivue v-slot="item">
+    <Notivue v-slot="item" position="bottom-right">
       <Notification :item="item" :theme="pastelTheme" title>
         <NotificationProgress :item="item" />
       </Notification>

--- a/src/runtime/components/app.vue
+++ b/src/runtime/components/app.vue
@@ -25,7 +25,7 @@ hook('page:finish', () => regenerate());
 
 <template>
   <main>
-    <Notivue v-slot="item" position="bottom-right">
+    <Notivue v-slot="item" position="top-right">
       <Notification :item="item" :theme="pastelTheme" title>
         <NotificationProgress :item="item" />
       </Notification>


### PR DESCRIPTION
## Problema

Las notificaciones aparecen en **top-center** (default de Notivue, sin `position` en el `<Notivue>` del shell `MKApp`) y cubren el header durante toda su duración (~4s). Al crear ítems en serie, el toast tapaba el botón `+ Adicionar` y se comía el siguiente clic — fricción real detectada al sembrar catálogo en E2E.

## Solución

`position="top-right"` en el `<Notivue>` de `runtime/components/app.vue`. Las notificaciones quedan ancladas arriba-derecha, visibles pero sin tapar el centro del header ni competir con acciones de la parte inferior (ej. la columna sticky de guardar). Aplica a todas las apps que montan `MKApp`.

Nota: requiere release del paquete y bump de `@merkaly/nuxt` en las apps consumidoras.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
