### PR TITLE
🟢 feat(format): formatMoney soporta notation/maximumFractionDigits (dinero compacto sin perder el /100)

### DIFF
--- a/src/runtime/components/format/FormatNumber.vue
+++ b/src/runtime/components/format/FormatNumber.vue
@@ -1,4 +1,8 @@
 <script lang="ts" setup>
+// Renders a plain number (counts, units, percentages) with compact notation and a
+// count-up animation. It does NOT divide by any base — for monetary values (stored
+// as integer cents) use MKFormatMoney / formatMoney, which divide by 100 and add the
+// currency symbol. Passing a money field here would render the raw cents.
 import type { PropType } from 'vue';
 import { computed, toRef } from 'vue';
 import { useCounterUp } from '../../composables/useCounterUp';

--- a/src/runtime/utils/formatMoney.ts
+++ b/src/runtime/utils/formatMoney.ts
@@ -3,11 +3,25 @@ export interface FormatMoneyOptions {
   currency?: string;
   locale?: string;
   mode?: Intl.NumberFormatOptionsStyle;
+  notation?: Intl.NumberFormatOptions['notation'];
+  maximumFractionDigits?: number;
 }
 
+/**
+ * Formats a monetary value held as an **integer in the minor unit (cents)**.
+ *
+ * Across Merkaly money is stored and transported as integer cents ($1.00 -> 100),
+ * so this helper divides by `base` (default 100) before formatting. Pass cents in,
+ * get a currency string out: `formatMoney(100)` -> `"$1.00"`.
+ *
+ * For non-currency numbers (counts, units, percentages) use `formatNumber` /
+ * `MKFormatNumber` instead — those do NOT divide and would show the raw cents.
+ */
 export function formatMoney(value: number, options: FormatMoneyOptions = {}) {
   return (value / (options.base ?? 100)).toLocaleString(options.locale ?? 'en-US', {
     style: options.mode ?? 'currency',
     currency: options.currency ?? 'USD',
+    notation: options.notation,
+    maximumFractionDigits: options.maximumFractionDigits,
   });
 }


### PR DESCRIPTION
## Contexto

En Merkaly el dinero se maneja como **enteros en centavos** ($1.00 → 100). `formatMoney` divide por `base` (100) y agrega símbolo; `formatNumber`/`MKFormatNumber` no dividen (son para cuentas/unidades/%).

## Problema

`formatMoney` solo reenviaba `style` y `currency` a `toLocaleString` — **no** `notation` ni `maximumFractionDigits`. Por eso, para lograr dinero **compacto** (`$124K`), los consumidores recurrían a `formatNumber(amount, { style:'currency', notation:'compact' })`, que **se saltea el `/100`** y muestra el monto 100× más grande.

## Cambio

- `FormatMoneyOptions` ahora acepta `notation` y `maximumFractionDigits`, y `formatMoney` los reenvía. Así el formato compacto de dinero se hace bien (con `/100` y símbolo).
- **JSDoc** en `formatMoney` documentando que espera **centavos** (divide por `base`).
- Comentario en `FormatNumber.vue` aclarando que es para números planos (no dinero).

Cambio aditivo y retrocompatible. Habilita corregir los consumidores que hoy formatean dinero con `formatNumber`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
