### PR TITLE
⚪ feat(select): exponer el slot no-options para empty-states personalizados

### DIFF
--- a/src/runtime/components/input/InputSelect.vue
+++ b/src/runtime/components/input/InputSelect.vue
@@ -149,10 +149,12 @@ const isRequired = computed(() => {
       <BSpinner v-if="isLoading" class="spinner" variant="primary" />
     </template>
 
-    <template #no-options="{ search, searching, loading: isLoading }">
-      <span v-if="isLoading">Searching for "{{ search }}"</span>
-      <span v-else-if="searching">No results for "{{ search }}"</span>
-      <span v-else>Type to search</span>
+    <template #no-options="scope">
+      <slot name="no-options" v-bind="scope">
+        <span v-if="scope.loading">Searching for "{{ scope.search }}"</span>
+        <span v-else-if="scope.searching">No results for "{{ scope.search }}"</span>
+        <span v-else>Type to search</span>
+      </slot>
     </template>
 
     <template #open-indicator="{ attributes }">


### PR DESCRIPTION
## Fricción que resuelve (habilitador)

> 🟡 **Dead-ends en selects vacíos**: en venta, el select de cliente solo dice "Type to search"; sin clientes no hay CTA "crear cliente aquí". Lo mismo con productos/fornecedores.

`MKInputSelect` tiene el texto del estado vacío **hardcodeado y en inglés** ("Type to search" / "No results for…"), dentro de su propio slot `#no-options`. Las apps no pueden ni localizarlo ni ofrecer una acción cuando la colección está vacía — exactamente el dead-end del onboarding.

## Propuesta

Convertir `#no-options` en un **slot passthrough** con el texto actual como fallback por defecto:

```vue
<template #no-options="scope">
  <slot name="no-options" v-bind="scope">
    <!-- comportamiento actual como fallback -->
  </slot>
</template>
```

Así, sin cambiar el comportamiento por defecto, las apps pueden inyectar contenido localizado o un CTA "＋ Criar" cuando un select no tiene opciones. El consumidor en admin (SelectAdapter + selects de produto/cliente/fornecedor) va en un PR aparte que aprovecha este slot.

Cambio mínimo, retrocompatible. Requiere release del paquete y bump en las apps (como #548/#549).

🤖 Generated with [Claude Code](https://claude.com/claude-code)