### PR TITLE
fix(datagrid): keep total in sync with item mutations

### DIFF
--- a/src/runtime/composables/useDatagrid.ts
+++ b/src/runtime/composables/useDatagrid.ts
@@ -67,6 +67,8 @@ export function useDatagrid<D = unknown>(params: OptionArgs<D>): DataGrid<D> {
           state.items.push(item as never);
         }
 
+        state.total += 1;
+
         return state.items as D[];
       },
 
@@ -75,6 +77,7 @@ export function useDatagrid<D = unknown>(params: OptionArgs<D>): DataGrid<D> {
 
         if (index !== -1) {
           state.items.splice(index, 1);
+          state.total = Math.max(0, state.total - 1);
         }
 
         return index;

--- a/test/runtime/composables/useDatagrid.test.ts
+++ b/test/runtime/composables/useDatagrid.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { useDatagrid } from '../../../src/runtime/composables/useDatagrid';
+
+describe('useDatagrid', () => {
+  it('increments total when appending or prepending items', () => {
+    const datagrid = useDatagrid<{ id: number }>({
+      columns: {},
+      items: [{ id: 1 }],
+      total: 1,
+    });
+
+    datagrid.fn.addItem({ id: 2 });
+    datagrid.fn.addItem({ id: 0 }, { mode: 'prepend' });
+
+    expect(datagrid.items).toEqual([{ id: 0 }, { id: 1 }, { id: 2 }]);
+    expect(datagrid.total).toBe(3);
+  });
+
+  it('decrements total only when an item is removed', () => {
+    const datagrid = useDatagrid<{ id: number }>({
+      columns: {},
+      items: [{ id: 1 }, { id: 2 }],
+      total: 2,
+    });
+
+    expect(datagrid.fn.removeItem(item => item.id === 3)).toBe(-1);
+    expect(datagrid.total).toBe(2);
+
+    expect(datagrid.fn.removeItem(item => item.id === 1)).toBe(0);
+    expect(datagrid.items).toEqual([{ id: 2 }]);
+    expect(datagrid.total).toBe(1);
+  });
+
+  it('does not decrement total below zero', () => {
+    const datagrid = useDatagrid<{ id: number }>({
+      columns: {},
+      items: [{ id: 1 }],
+    });
+
+    datagrid.fn.removeItem(item => item.id === 1);
+
+    expect(datagrid.total).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problema

`addItem` y `removeItem` modificaban `items`, pero dejaban `total` desactualizado y obligaban a los consumidores a mantenerlo manualmente.

## Cambio

- Incrementa `total` cuando `addItem` inserta un elemento.
- Decrementa `total` solamente cuando `removeItem` encuentra y elimina un elemento.
- Evita que `total` quede por debajo de cero.
- Añade cobertura para append, prepend, eliminación exitosa y predicate sin coincidencia.

## Validación

- `pnpm test -- test/runtime/composables/useDatagrid.test.ts`
- `pnpm exec eslint src/runtime/composables/useDatagrid.ts test/runtime/composables/useDatagrid.test.ts`
- `pnpm test:types` continúa fallando por errores preexistentes fuera de este cambio.